### PR TITLE
Added optional parameter output mode | hsl or hex/default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const tailwindcssPaletteGenerator = input => {
+const tailwindcssPaletteGenerator = (input, mode = 'hex') => {
   // addColor function
   const addColor = color => {
     let colorParams = {
@@ -54,7 +54,7 @@ const tailwindcssPaletteGenerator = input => {
     b = Math.round(b * (1 - intensity));
 
     // return the new hex color
-    return rgbToHex(r, g, b);
+    return mode === 'hsl' ? rgbToHsl(r, g, b) : rgbToHex(r, g, b);
   };
 
   // lighten function
@@ -68,7 +68,7 @@ const tailwindcssPaletteGenerator = input => {
     b = Math.round(b + (255 - b) * intensity);
 
     // return the new hex color
-    return rgbToHex(r, g, b);
+    return mode === 'hsl' ? rgbToHsl(r, g, b) : rgbToHex(r, g, b);
   };
 
   // hexToRgb function
@@ -84,6 +84,27 @@ const tailwindcssPaletteGenerator = input => {
 
   // rgbToHex function
   const rgbToHex = (r, g, b) => `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+
+  function rgbToHsl(r, g, b) {
+    r /= 255, g /= 255, b /= 255;
+    var max = Math.max(r, g, b), min = Math.min(r, g, b);
+    var h, s, l = (max + min) / 2;
+
+    if (max == min) {
+      h = s = 0; // achromatic
+    } else {
+      var d = max - min;
+      s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+      switch (max) {
+        case r: h = (g - b) / d + (g < b ? 6 : 0); break;
+        case g: h = (b - r) / d + 2; break;
+        case b: h = (r - g) / d + 4; break;
+      }
+      h /= 6;
+    }
+
+    return `hsl(var(--brand-hue, ${Math.floor(h * 360)}) ${Math.floor(s * 100)}% ${Math.floor(l * 100)}%)`;
+  }
 
   // toHex function
   const toHex = n => `0${n.toString(16)}`.slice(-2).toUpperCase();


### PR DESCRIPTION
Added **optional** parameter to output as hsl with 'fallback' custom property.

If the mode parameter is not entered, the legacy behavior is preserved.

**Before**
```js
const color = paletteGenerator('#60976c');
console.log(color);

{
  primary: {
    '50': '#F7FAF8',
    '100': '#EFF5F0',
    '200': '#D7E5DA',
    '300': '#BFD5C4',
    '400': '#90B698',
    '500': '#60976C',
    '600': '#568861',
    '700': '#487151',
    '800': '#3A5B41',
    '900': '#2F4A35'
  }
}

```

**After**
Uses a custom property `--brand-hue` for the hue value which allows the user to override it, and uses the generated hue value as the fallback parameter.

```js
const color = paletteGenerator('#60976c', 'hsl');
console.log(color);

{
  primary: {
    '50': 'hsl(var(--brand-hue, 140) 23% 97%)',
    '100': 'hsl(var(--brand-hue, 129) 23% 94%)',
    '200': 'hsl(var(--brand-hue, 132) 21% 87%)',
    '300': 'hsl(var(--brand-hue, 133) 20% 79%)',
    '400': 'hsl(var(--brand-hue, 132) 20% 63%)',
    '500': 'hsl(var(--brand-hue, 133) 22% 48%)',
    '600': 'hsl(var(--brand-hue, 133) 22% 43%)',
    '700': 'hsl(var(--brand-hue, 133) 22% 36%)',
    '800': 'hsl(var(--brand-hue, 132) 22% 29%)',
    '900': 'hsl(var(--brand-hue, 133) 22% 23%)'
  }
}
```