### PR TITLE
Add anchor option to palette generator for shade 500 color pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,82 +4,74 @@ All notable changes to this project will be documented in this file. See [commit
 
 ## [4.0.0](https://github.com/bobthered/tailwindcss-palette-generator/compare/v3.3.2...v4.0.0) (2024-10-12)
 
-
 ### ⚠ BREAKING CHANGES
 
-* scaffold out v4.0.0 project
+- scaffold out v4.0.0 project
 
 ### Features
 
-* add back MIT license ([aa87e0d](https://github.com/bobthered/tailwindcss-palette-generator/commit/aa87e0db19a404d06fdd40c6d975efb92e26f717))
-* add both cjs & esm tsup configs ([b5bb465](https://github.com/bobthered/tailwindcss-palette-generator/commit/b5bb465734960db47fdab6d26f0be6f508f0928a))
-* add example tests ([4927fa2](https://github.com/bobthered/tailwindcss-palette-generator/commit/4927fa210ff98dbbe9645219c687a3bd4e86a5f9))
-* add explicit return type ([94e2343](https://github.com/bobthered/tailwindcss-palette-generator/commit/94e2343c6a91e2b5fd6840946cc203331cc0634e))
-* add publish settings ([8d57742](https://github.com/bobthered/tailwindcss-palette-generator/commit/8d57742c5d3f14df9433111595fe4856ee462183))
-* ignore /dist folder ([18353b8](https://github.com/bobthered/tailwindcss-palette-generator/commit/18353b87b4e5b8ab255d50a1d9653d4e0c3a866c))
-* only export tailwindcssPaletteGenerator function ([de49c2a](https://github.com/bobthered/tailwindcss-palette-generator/commit/de49c2ae6d5855105f6d1bd7686ac7fc9dff9aa2))
-* remove commented out exports ([b623808](https://github.com/bobthered/tailwindcss-palette-generator/commit/b623808619418132667ef95a7bb335879b9ba341))
-* rewrite base library ([f5306c0](https://github.com/bobthered/tailwindcss-palette-generator/commit/f5306c0a78aa704113c4696d8c57d02ad5d34010))
-* scaffold out v4.0.0 project ([0e18202](https://github.com/bobthered/tailwindcss-palette-generator/commit/0e18202ff45dce14c1784fa37ea2d64469e7153c))
-* update package.json ([384197e](https://github.com/bobthered/tailwindcss-palette-generator/commit/384197ea3490a6ab47799f218e62a33c4322fc20))
-* update README.md for esm import syntax ([afe394e](https://github.com/bobthered/tailwindcss-palette-generator/commit/afe394ee8726503a3550fa6eb60e9c34c99a0058))
-* update release script ([40c8eb4](https://github.com/bobthered/tailwindcss-palette-generator/commit/40c8eb44188048114de267e65e5537e7a5d6173f))
-* update to v4.0.0 ([9f2cc65](https://github.com/bobthered/tailwindcss-palette-generator/commit/9f2cc65aafa6237e6aaebf5ad7bf9869b1785f9e))
+- add back MIT license ([aa87e0d](https://github.com/bobthered/tailwindcss-palette-generator/commit/aa87e0db19a404d06fdd40c6d975efb92e26f717))
+- add both cjs & esm tsup configs ([b5bb465](https://github.com/bobthered/tailwindcss-palette-generator/commit/b5bb465734960db47fdab6d26f0be6f508f0928a))
+- add example tests ([4927fa2](https://github.com/bobthered/tailwindcss-palette-generator/commit/4927fa210ff98dbbe9645219c687a3bd4e86a5f9))
+- add explicit return type ([94e2343](https://github.com/bobthered/tailwindcss-palette-generator/commit/94e2343c6a91e2b5fd6840946cc203331cc0634e))
+- add publish settings ([8d57742](https://github.com/bobthered/tailwindcss-palette-generator/commit/8d57742c5d3f14df9433111595fe4856ee462183))
+- ignore /dist folder ([18353b8](https://github.com/bobthered/tailwindcss-palette-generator/commit/18353b87b4e5b8ab255d50a1d9653d4e0c3a866c))
+- only export tailwindcssPaletteGenerator function ([de49c2a](https://github.com/bobthered/tailwindcss-palette-generator/commit/de49c2ae6d5855105f6d1bd7686ac7fc9dff9aa2))
+- remove commented out exports ([b623808](https://github.com/bobthered/tailwindcss-palette-generator/commit/b623808619418132667ef95a7bb335879b9ba341))
+- rewrite base library ([f5306c0](https://github.com/bobthered/tailwindcss-palette-generator/commit/f5306c0a78aa704113c4696d8c57d02ad5d34010))
+- scaffold out v4.0.0 project ([0e18202](https://github.com/bobthered/tailwindcss-palette-generator/commit/0e18202ff45dce14c1784fa37ea2d64469e7153c))
+- update package.json ([384197e](https://github.com/bobthered/tailwindcss-palette-generator/commit/384197ea3490a6ab47799f218e62a33c4322fc20))
+- update README.md for esm import syntax ([afe394e](https://github.com/bobthered/tailwindcss-palette-generator/commit/afe394ee8726503a3550fa6eb60e9c34c99a0058))
+- update release script ([40c8eb4](https://github.com/bobthered/tailwindcss-palette-generator/commit/40c8eb44188048114de267e65e5537e7a5d6173f))
+- update to v4.0.0 ([9f2cc65](https://github.com/bobthered/tailwindcss-palette-generator/commit/9f2cc65aafa6237e6aaebf5ad7bf9869b1785f9e))
 
 ### [3.3.2](https://github.com/bobthered/tailwindcss-palette-generator/compare/v3.3.1...v3.3.2) (2024-10-10)
 
-
 ### Bug Fixes
 
-* update tsup config ([9dfc563](https://github.com/bobthered/tailwindcss-palette-generator/commit/9dfc56324bb957f61ef0b4c41f2a0c8ea4794d4a))
+- update tsup config ([9dfc563](https://github.com/bobthered/tailwindcss-palette-generator/commit/9dfc56324bb957f61ef0b4c41f2a0c8ea4794d4a))
 
 ### [3.3.1](https://github.com/bobthered/tailwindcss-palette-generator/compare/v3.3.0...v3.3.1) (2024-10-10)
 
 ## [3.3.0](https://github.com/bobthered/tailwindcss-palette-generator/compare/v3.2.4...v3.3.0) (2024-10-10)
 
-
 ### Features
 
-* provide both cjs & esm exports ([2f82607](https://github.com/bobthered/tailwindcss-palette-generator/commit/2f826079a331801f98e7fc8b7ab3510a33668e88))
-* publish to jsr.io ([b4b40cc](https://github.com/bobthered/tailwindcss-palette-generator/commit/b4b40ccb276d3bd601905824fc8cbbf8b2fc74c7))
+- provide both cjs & esm exports ([2f82607](https://github.com/bobthered/tailwindcss-palette-generator/commit/2f826079a331801f98e7fc8b7ab3510a33668e88))
+- publish to jsr.io ([b4b40cc](https://github.com/bobthered/tailwindcss-palette-generator/commit/b4b40ccb276d3bd601905824fc8cbbf8b2fc74c7))
 
 ### [3.2.4](https://github.com/bobthered/tailwindcss-palette-generator/compare/v3.2.3...v3.2.4) (2024-05-23)
 
 ### [3.2.3](https://github.com/bobthered/tailwindcss-palette-generator/compare/v3.2.2...v3.2.3) (2023-11-28)
 
-
 ### Bug Fixes
 
-* **package.json:** add main key and require exports ([f0e94c3](https://github.com/bobthered/tailwindcss-palette-generator/commit/f0e94c3303857dcd80ee6c04d2b998e98a3e51db))
+- **package.json:** add main key and require exports ([f0e94c3](https://github.com/bobthered/tailwindcss-palette-generator/commit/f0e94c3303857dcd80ee6c04d2b998e98a3e51db))
 
 ### [3.2.2](https://github.com/bobthered/tailwindcss-palette-generator/compare/v3.2.1...v3.2.2) (2023-11-18)
 
-
 ### Bug Fixes
 
-* **gh-pages:** update github pages ([fc13a02](https://github.com/bobthered/tailwindcss-palette-generator/commit/fc13a0278cf2a08622dc98cf55449b3bd42b2c03))
-* **prerend:** change site to prerender to work with github pages ([b03dd20](https://github.com/bobthered/tailwindcss-palette-generator/commit/b03dd2002e28c9b73e748c26eadd898e060d22e6))
+- **gh-pages:** update github pages ([fc13a02](https://github.com/bobthered/tailwindcss-palette-generator/commit/fc13a0278cf2a08622dc98cf55449b3bd42b2c03))
+- **prerend:** change site to prerender to work with github pages ([b03dd20](https://github.com/bobthered/tailwindcss-palette-generator/commit/b03dd2002e28c9b73e748c26eadd898e060d22e6))
 
 ### [3.2.1](https://github.com/bobthered/tailwindcss-palette-generator/compare/v3.2.0...v3.2.1) (2023-11-17)
 
-
 ### Bug Fixes
 
-* **gh-pages:** automatically send to gh-pages branch ([45c2219](https://github.com/bobthered/tailwindcss-palette-generator/commit/45c2219a7574829fcc53ae03097425604dd95bde))
+- **gh-pages:** automatically send to gh-pages branch ([45c2219](https://github.com/bobthered/tailwindcss-palette-generator/commit/45c2219a7574829fcc53ae03097425604dd95bde))
 
 ## 3.2.0 (2023-11-17)
 
-
 ### Features
 
-* add logo-tailwindcss.png ([3014ec8](https://github.com/bobthered/tailwindcss-palette-generator/commit/3014ec8d24fe0bf0a1873833356e14d46fb7c228))
-* add typescript support ([a28edfe](https://github.com/bobthered/tailwindcss-palette-generator/commit/a28edfee3332772e347a6fdc66b13ee0419ef239))
-
+- add logo-tailwindcss.png ([3014ec8](https://github.com/bobthered/tailwindcss-palette-generator/commit/3014ec8d24fe0bf0a1873833356e14d46fb7c228))
+- add typescript support ([a28edfe](https://github.com/bobthered/tailwindcss-palette-generator/commit/a28edfee3332772e347a6fdc66b13ee0419ef239))
 
 ### Bug Fixes
 
-* add .nojekyll for gh-pages ([1a57cb6](https://github.com/bobthered/tailwindcss-palette-generator/commit/1a57cb649f5d38ca45cc7d71a4b57c517bcf3cd0))
-* esm module path correction ([e75c624](https://github.com/bobthered/tailwindcss-palette-generator/commit/e75c624a5497ca30eda4fdb3910ee6786925a552))
-* svelte.config.js paths for gh-pages ([a0ff243](https://github.com/bobthered/tailwindcss-palette-generator/commit/a0ff243bdbcb1b30446e01a7b854de6ff4db3534))
-* update documentation in README.md ([fa0bd45](https://github.com/bobthered/tailwindcss-palette-generator/commit/fa0bd45fb224e3771fc8844661bef9bcfec41e35))
-* update README.md with examples ([7060fa6](https://github.com/bobthered/tailwindcss-palette-generator/commit/7060fa6cadaa9f00d5f8d304f9245ff51fb3260e))
+- add .nojekyll for gh-pages ([1a57cb6](https://github.com/bobthered/tailwindcss-palette-generator/commit/1a57cb649f5d38ca45cc7d71a4b57c517bcf3cd0))
+- esm module path correction ([e75c624](https://github.com/bobthered/tailwindcss-palette-generator/commit/e75c624a5497ca30eda4fdb3910ee6786925a552))
+- svelte.config.js paths for gh-pages ([a0ff243](https://github.com/bobthered/tailwindcss-palette-generator/commit/a0ff243bdbcb1b30446e01a7b854de6ff4db3534))
+- update documentation in README.md ([fa0bd45](https://github.com/bobthered/tailwindcss-palette-generator/commit/fa0bd45fb224e3771fc8844661bef9bcfec41e35))
+- update README.md with examples ([7060fa6](https://github.com/bobthered/tailwindcss-palette-generator/commit/7060fa6cadaa9f00d5f8d304f9245ff51fb3260e))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "tailwindcss-palette-generator",
+	"name": "@bobthered/tailwindcss-palette-generator",
 	"version": "4.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "tailwindcss-palette-generator",
+			"name": "@bobthered/tailwindcss-palette-generator",
 			"version": "4.0.0",
 			"license": "MIT",
 			"devDependencies": {
@@ -7052,21 +7052,6 @@
 				"lodash.sortby": "^4.7.0",
 				"tr46": "^1.0.1",
 				"webidl-conversions": "^4.0.2"
-			}
-		},
-		"node_modules/tsup/node_modules/yaml": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-			"integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"lint": "prettier --check . && eslint .",
 		"format": "prettier --write .",
 		"package": "tsup --config ./tsup.esm.minified.ts && tsup --config ./tsup.cjs.minified.ts",
+		"prepack": "npm run package",
 		"release:dry-run": "npm run package && vitest run && commit-and-tag-version --dry-run",
 		"release": "npm run package && vitest run && commit-and-tag-version && git push --follow-tags origin main && npm publish && npx jsr publish"
 	},

--- a/src/lib/generateColor.ts
+++ b/src/lib/generateColor.ts
@@ -2,19 +2,46 @@ import { hexToHSL } from './hexToHSL.js';
 import { hslToHex } from './hslToHex.js';
 import { type Color, type HSL, type Shade } from './types.js';
 
+/**
+ * Default anchor shade lightness (shade 500 = 46).
+ * Used as the reference point for proportional scaling when anchor mode is enabled.
+ */
+const ANCHOR_LIGHTNESS = 46;
+
+/**
+ * Scales shade lightness values so the input color's actual lightness
+ * lands exactly at the anchor shade (500), and other shades distribute
+ * proportionally between 0–100.
+ *
+ * Shades lighter than the anchor scale between the color's lightness and 100.
+ * Shades darker than the anchor scale between 0 and the color's lightness.
+ */
+const scaleLightness = (shadeLightness: number, colorLightness: number): number => {
+	if (shadeLightness >= ANCHOR_LIGHTNESS) {
+		// Lighter shades: map [ANCHOR_LIGHTNESS..100] → [colorLightness..100]
+		const ratio = (shadeLightness - ANCHOR_LIGHTNESS) / (100 - ANCHOR_LIGHTNESS);
+		return colorLightness + ratio * (100 - colorLightness);
+	}
+	// Darker shades: map [0..ANCHOR_LIGHTNESS] → [0..colorLightness]
+	const ratio = shadeLightness / ANCHOR_LIGHTNESS;
+	return ratio * colorLightness;
+};
+
 export const generateColor = ({
 	hex,
 	preserve,
+	anchor,
 	shades
 }: {
 	hex: string;
 	preserve: boolean;
+	anchor: boolean;
 	shades: Shade[];
 }): Color => {
 	// convert hex to hsl
 	const colorHSL = hexToHSL(hex);
 
-	// initiate lightnessDelta map
+	// initiate lightnessDelta map (used by preserve mode)
 	const lightnessDelta: Record<string | number, number> = {};
 
 	// create object
@@ -22,8 +49,11 @@ export const generateColor = ({
 		// destructure h, s, l
 		const { h, s, l } = colorHSL;
 
+		// When anchor is enabled, scale lightness so the input color anchors at shade 500
+		const adjustedLightness = anchor ? Math.round(scaleLightness(lightness, l)) : lightness;
+
 		// generate shade hsl
-		const hsl: HSL = { h, s, l: lightness };
+		const hsl: HSL = { h, s, l: adjustedLightness };
 
 		// convert hsl to hex
 		const hex = hslToHex(hsl);
@@ -31,16 +61,21 @@ export const generateColor = ({
 		// update map
 		obj[name] = hex;
 
-		// update lightnessDelta if preserving color
-		if (preserve) lightnessDelta[name] = Math.abs(l - lightness);
+		// update lightnessDelta if preserving color (non-anchor mode)
+		if (preserve && !anchor) lightnessDelta[name] = Math.abs(l - lightness);
 
 		return obj;
 	}, {});
 
-	// if preserving color, inject original color at closest shade
-	if (preserve) {
+	if (anchor) {
+		// Force the exact input hex at shade 500 to avoid any rounding drift
+		const anchorShade = shades.find((s) => s.lightness === ANCHOR_LIGHTNESS);
+		if (anchorShade) {
+			obj[anchorShade.name] = hex.startsWith('#') ? hex : `#${hex}`;
+		}
+	} else if (preserve) {
 		const [closestShade] = Object.keys(lightnessDelta).sort(
-			(a, b) => lightnessDelta[a] - lightnessDelta[b]
+			(a, b) => (lightnessDelta[a] ?? 0) - (lightnessDelta[b] ?? 0)
 		);
 		obj[closestShade] = hex;
 	}

--- a/src/lib/tailwindcssPaletteGenerator.ts
+++ b/src/lib/tailwindcssPaletteGenerator.ts
@@ -18,6 +18,7 @@ export const tailwindcssPaletteGenerator = (options: string | string[] | Options
 			'denary'
 		],
 		preserve: true,
+		anchor: false,
 		shades: [
 			{ name: '50', lightness: 98 },
 			{ name: '100', lightness: 95 },
@@ -41,16 +42,22 @@ export const tailwindcssPaletteGenerator = (options: string | string[] | Options
 	options = Object.assign(defaults, options);
 
 	// destructure options
-	const { colors, names, preserve, shades } = options;
+	const { colors, names, preserve, anchor, shades } = options;
 
-	if (colors === undefined || names === undefined || preserve === undefined || shades === undefined)
+	if (
+		colors === undefined ||
+		names === undefined ||
+		preserve === undefined ||
+		anchor === undefined ||
+		shades === undefined
+	)
 		return {};
 
 	// create palette
 	const palette: Palette = colors.reduce(
 		(obj: Record<string | number, Record<string | number, string>>, hex, index) => {
-			const name = names[index];
-			const color = generateColor({ hex, preserve, shades });
+			const name = names[index] as string;
+			const color = generateColor({ hex, preserve, anchor, shades });
 			obj[name] = color;
 			return obj;
 		},

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,6 +10,7 @@ export type Options = {
 	colors?: string[];
 	names?: string[];
 	preserve?: boolean;
+	anchor?: boolean;
 	shades?: Shade[];
 };
 


### PR DESCRIPTION
## Summary

Adds an anchor option to the palette generator that forces the input color to always land at shade 500, with all other shades scaled proportionally around it.

## Problem

The existing preserve option places the input hex at whichever shade has the closest natural lightness. For dark brand colors (e.g., #008000 at lightness 25%), this meant the color ended up at shade 700 — while shade 500 (used by Nuxt UI for bg-primary, buttons, etc.) showed a different, lighter color.

## Solution

A new anchor: boolean option (defaults to false) that, when enabled:

- Scales shade lightness values proportionally so the input color's actual lightness maps to shade 500
- Lighter shades (50–400) distribute between the color's lightness and 100%
- Darker shades (600–950) distribute between 0% and the color's lightness
- Forces the exact input hex at shade 500 to eliminate rounding drift

The existing preserve behavior is untouched when anchor is false.